### PR TITLE
Restrict NumPy to Versions <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 keywords = ["web scraping", "web crawling", "evaluation"]
 dependencies = [
     "more-itertools==9.1.0",
+    "numpy<=2.0.0",
     "pandas==2.0.3",
     "resiliparse==0.14.5",
     "seaborn==0.13.2",


### PR DESCRIPTION
Addresses the incompatible update of NumPy raised in #4.